### PR TITLE
Add back button to chat

### DIFF
--- a/Ampyre/src/pages/Chat.jsx
+++ b/Ampyre/src/pages/Chat.jsx
@@ -208,7 +208,15 @@ export default function Chat() {
           {/* Header */}
           <div className="p-4 border-b border-gray-200">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold">Messages</h2>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => navigate('/dashboard')}
+                  className="p-2 rounded-lg hover:bg-gray-100 transition"
+                >
+                  <ArrowLeft className="w-5 h-5" />
+                </button>
+                <h2 className="text-lg font-semibold">Messages</h2>
+              </div>
               <button
                 onClick={() => navigate('/buddies')}
                 className="p-2 rounded-lg hover:bg-gray-100 transition"


### PR DESCRIPTION
Add a back button to the chat page header to navigate to the dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-e453a2a3-3246-44bd-a693-4d47dd8ba44d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e453a2a3-3246-44bd-a693-4d47dd8ba44d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

